### PR TITLE
perf: faster port search

### DIFF
--- a/packages/plugin-mongchhi/src/findPortsInUse.ts
+++ b/packages/plugin-mongchhi/src/findPortsInUse.ts
@@ -31,7 +31,7 @@ function findPortsInUse(): number[] {
             const matcher = /[:.](\d+)\s/.exec(line);
             if (matcher?.[1]) {
               const port = Number(matcher[1]);
-              if (port > 1025 && port < 65535) {
+              if (port >= 1025 && port <= 65535) {
                 ports.add(port);
               }
             }

--- a/packages/plugin-mongchhi/src/findPortsInUse.ts
+++ b/packages/plugin-mongchhi/src/findPortsInUse.ts
@@ -1,0 +1,46 @@
+import { spawnSync } from 'child_process';
+import os from 'os';
+
+const platform = os.platform();
+
+interface Commands {
+  [platform: string]: {
+    cmd: string;
+    args: string[];
+  };
+}
+
+const commands: Commands = {
+  linux: { cmd: 'netstat', args: ['-a', '-n'] },
+  darwin: { cmd: 'netstat', args: ['-a', '-n'] },
+  win3: { cmd: 'netstat', args: ['-a', '-n'] },
+};
+
+function findPortsInUse(): number[] {
+  const ports: Set<number> = new Set();
+  const { cmd, args } = commands[platform];
+  const proc = spawnSync(cmd, args, { stdio: 'pipe', encoding: 'utf-8' });
+  if (proc.stderr) {
+    console.error(Error(proc.stderr));
+  }
+  if (proc.output) {
+    proc.output.forEach((output) => {
+      if (output) {
+        output.split('\n').forEach((line) => {
+          if (line.indexOf('LISTEN') > -1) {
+            const matcher = /[:.](\d+)\s/.exec(line);
+            if (matcher?.[1]) {
+              const port = Number(matcher[1]);
+              if (port > 1025 && port < 65535) {
+                ports.add(port);
+              }
+            }
+          }
+        });
+      }
+    });
+  }
+  return Array.from(ports);
+}
+
+export default findPortsInUse;

--- a/packages/plugin-mongchhi/src/index.ts
+++ b/packages/plugin-mongchhi/src/index.ts
@@ -93,12 +93,12 @@ export default (api: IApi) => {
       logger.profile('find', 'find live umi app...');
       // 寻找占用中的端口
       const portsInUse = await findPortsInUse();
-      for (const port of portsInUse) {
-        const json: any = await getUmiAppByPort(port);
+      const res = await Promise.all(portsInUse.map((port) => getUmiAppByPort(port)));
+      res.forEach((json) => {
         if (json && json?.cwd) {
           liveUmiApp[json?.cwd] = json;
         }
-      }
+      });
       logger.profile('find');
       const keys = Object.keys(liveUmiApp);
       if (keys && keys.length > 0) {

--- a/packages/plugin-mongchhi/src/index.ts
+++ b/packages/plugin-mongchhi/src/index.ts
@@ -1,6 +1,7 @@
 import { IApi } from '@mongchhi/types';
 import { localUmiAppData } from '@mongchhi/utils';
 import { logger } from '@umijs/utils';
+import findPortsInUse from './findPortsInUse';
 
 const getAppDataUrl = (port: number | string) => {
   return `http://localhost:${port}/__umi/api/app-data`;
@@ -33,52 +34,6 @@ const getUmiAppByPort = async (port: number | string) => {
   return json;
 };
 
-/**
- * 检测端口是否被占用
- * @param port 端口号
- * @returns 端口是否被占用 true or false
- */
-const isPortOccupied = (port: number) => {
-  const net = require('net');
-  let listener = net.createServer().listen(port);
-  return new Promise((resolve) => {
-    // 如果监听成功，表示端口没有被其他服务占用，端口可用，取消监听，返回结果false
-    listener.on('listening', () => {
-      listener.close();
-      resolve(false);
-    });
-    // 如果监听出错，并且错误原因是端口正在使用中, 返回结果true, 其它情况返回false
-    listener.on('error', (err: any) => {
-      listener.close();
-      if (err.code === 'EADDRINUSE') {
-        resolve(true);
-      } else {
-        resolve(false);
-      }
-    });
-  });
-};
-
-/**
- * 查找正在使用中的端口
- * @returns 存储所有正在使用中端口的数组
- */
-const findPortsInUse = async () => {
-  let result: number[] = [];
-  // 0~1023为系统端口 1024为保留端口
-  for (let i = 1025; i < 65535; i++) {
-    try {
-      const status = await isPortOccupied(i);
-      if (status) {
-        result.push(i);
-      }
-    } catch (e: any) {
-      break;
-    }
-  }
-  return result;
-};
-
 export default (api: IApi) => {
   api.registerCommand({
     name: 'mongchhi',
@@ -89,11 +44,13 @@ export default (api: IApi) => {
       // 读取 appData 缓存
       // 从缓存页面中读取，或者从页面中打开磁盘目录
       // find live umi app
-      const liveUmiApp = localUmiAppData.get();
+      const liveUmiApp: any = localUmiAppData.get();
       logger.profile('find', 'find live umi app...');
       // 寻找占用中的端口
-      const portsInUse = await findPortsInUse();
-      const res = await Promise.all(portsInUse.map((port) => getUmiAppByPort(port)));
+      const portsInUse = findPortsInUse();
+      const res = await Promise.all(
+        portsInUse.map((port) => getUmiAppByPort(port)),
+      );
       res.forEach((json) => {
         if (json && json?.cwd) {
           liveUmiApp[json?.cwd] = json;


### PR DESCRIPTION
umi app 查找速度大幅度提升，本机测试 2100ms -> 1100ms

- [x] 优化"获取使用中端口"代码，使用 netstat 获取和筛选使用中端口
- [x] 优化 for of ... await fetch 代码，异步获取 app data